### PR TITLE
Proposed refactor / changes

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -4,12 +4,15 @@
   ],
   "workspace.ignoreSubmodules": false,
   "diagnostics.globals": [
-    "vim"
+    "vim",
+    "FzfLua",
+    "MiniTest",
   ],
   "diagnostics.disable": [
     "missing-fields"
   ],
   "workspace.library": [
-    "$VIMRUNTIME"
+    "$VIMRUNTIME",
+    "${3rd}/luv/library",
   ]
 }

--- a/lua/fzf-lua-frecency/fn_transform.lua
+++ b/lua/fzf-lua-frecency/fn_transform.lua
@@ -1,35 +1,56 @@
 local M = {}
 
 --- @class GetFnTransformOpts
---- @field cwd string
+--- @field stat_file boolean
 --- @field display_score boolean
---- @field debug boolean
 --- @field db_dir string
---- @field fd_cmd string
 
---- @param opts GetFnTransformOpts
-M.get_fn_transform = function(opts)
-  return function(abs_file)
-    local fzf_lua = require "fzf-lua"
+--- @param rpc_opts GetFnTransformOpts
+M.get_fn_transform = function(rpc_opts)
+  return function(abs_file, opts)
+    -- Call fzf-lua's entry maker, filters out cwd/cwd_only/file_ignore_patterns, etc
+    -- will also make the file path relative, use formatters, path_shorten, etc
+    local entry = FzfLua.make_entry.file(abs_file, opts)
+    if not entry then return end
+
+    -- If we don't display score or test for the file on disk stop here
+    if not rpc_opts.display_score and not rpc_opts.stat_file then
+      return entry
+    end
+
     local fs = require "fzf-lua-frecency.fs"
     local h = require "fzf-lua-frecency.helpers"
     local algo = require "fzf-lua-frecency.algo"
     local now = os.time()
+    local db_index = 1
 
-    local dated_files_path = h.get_dated_files_path(opts.db_dir)
-    local max_scores_path = h.get_max_scores_path(opts.db_dir)
+    if not _G._fzf_lua_frecency_dated_files then
+      local dated_files_path = h.get_dated_files_path(rpc_opts.db_dir)
+      local max_scores_path = h.get_max_scores_path(rpc_opts.db_dir)
+      _G._fzf_lua_frecency_dated_files = fs.read(dated_files_path)
+      _G._fzf_lua_frecency_max_scores = fs.read(max_scores_path)
+     end
 
-    local dated_files = fs.read(dated_files_path)
-    local max_scores = fs.read(max_scores_path)
-    local max_score = h.default(max_scores[opts.cwd], 0)
+    local dated_files = _G._fzf_lua_frecency_dated_files
+    local max_scores = _G._fzf_lua_frecency_max_scores
+    local max_score = h.default(max_scores[db_index], 0)
     local max_score_len = #h.exact_decimals(max_score, 2)
 
-    local rel_file = vim.fs.relpath(opts.cwd, abs_file)
-    local entry = fzf_lua.make_entry.file(rel_file, { file_icons = true, color_icons = true, })
+    local date_at_score_one = dated_files[db_index] and dated_files[db_index][abs_file] or nil
 
-    if opts.display_score then
+    -- Only "stat" files from the db, fd|rg enumerated files guaranteed to exist
+    if rpc_opts.stat_file and date_at_score_one then
+      if not vim.uv.fs_stat(abs_file) then
+        vim.schedule(function()
+          -- File no longer exists,remove from the db, schedule to avoid E5560
+          algo.update_file_score(abs_file, { update_type = "remove", })
+        end)
+        return
+      end
+    end
+
+    if rpc_opts.display_score then
       local score = nil
-      local date_at_score_one = dated_files[opts.cwd] and dated_files[opts.cwd][abs_file] or nil
       if date_at_score_one then
         score = algo.compute_score { now = now, date_at_score_one = date_at_score_one, }
       end
@@ -42,7 +63,7 @@ M.get_fn_transform = function(opts)
       else
         formatted_score = h.pad_str(h.exact_decimals(score, 2), max_score_len)
       end
-      return ("%s %s"):format(formatted_score, entry)
+      return ("%s%s%s"):format(formatted_score, FzfLua.utils.nbsp, entry)
     end
 
     return entry

--- a/lua/fzf-lua-frecency/helpers.lua
+++ b/lua/fzf-lua-frecency/helpers.lua
@@ -75,11 +75,9 @@ M.get_default_db_dir = function()
 end
 
 --- @param db_dir string
---- @param cwd string
-M.get_sorted_files_path = function(db_dir, cwd)
+M.get_sorted_files_path = function(db_dir)
   db_dir = M.default(db_dir, M.get_default_db_dir())
-  cwd = M.default(cwd, vim.fn.getcwd())
-  return vim.fs.joinpath(db_dir, "cwds", cwd, "sorted-files.txt")
+  return vim.fs.joinpath(db_dir, "sorted-files.txt")
 end
 
 --- @param db_dir string

--- a/lua/fzf-lua-frecency/init.lua
+++ b/lua/fzf-lua-frecency/init.lua
@@ -1,145 +1,193 @@
+local h = require "fzf-lua-frecency.helpers"
+local algo = require "fzf-lua-frecency.algo"
+
+-- Runtime path for this package, to be used with the headless instance for loading
+local __FILE__ = debug.getinfo(1, "S").source:gsub("^@", "")
+local __RTP__ = vim.fn.fnamemodify(__FILE__, ":h:h:h")
+
 local M = {}
 
---- @class FzfLuaFrecencyTbl
+--- @class FrecencyFnOpts
 --- @field debug boolean
 --- @field db_dir string
---- @field fd_cmd string
+--- @field all_files boolean
+--- @field stat_file boolean
 --- @field display_score boolean
-
---- @class FrecencyFnOpts
---- @field fzf_lua_frecency FzfLuaFrecencyTbl
 --- @field [string] any any fzf-lua option
 
---- @param opts FrecencyFnOpts
-M.frecency = function(opts)
-  opts = opts or {}
-  local h = require "fzf-lua-frecency.helpers"
 
-  local cwd = h.default(opts.cwd, vim.fn.getcwd())
-  local frecency_opts = h.default(opts.fzf_lua_frecency, {})
-  local display_score = h.default(frecency_opts.display_score, false)
-  local debug = h.default(frecency_opts.debug, false)
-  local db_dir = h.default(frecency_opts.db_dir, h.get_default_db_dir())
-  local default_fd_cmd = table.concat({
-    "fd",
+local function get_files_cmd(opts)
+  local cmd
+  local fd_args = table.concat({
     "--absolute-path",
     "--type", "f",
     "--type", "l",
     "--exclude", ".git",
-    "--base-directory", cwd,
   }, " ")
-  local fd_cmd = h.default(frecency_opts.fd_cmd, default_fd_cmd)
-
-
-  local sorted_files_path = h.get_sorted_files_path(db_dir, cwd)
-  local fzf_lua = require "fzf-lua"
-  local algo = require "fzf-lua-frecency.algo"
-
-  local wrapped_enter = function(action)
-    return function(selected, action_opts)
-      vim.schedule(function()
-        for _, sel in ipairs(selected) do
-          if display_score then
-            sel = h.strip_score(sel)
-          end
-          -- https://github.com/ibhagwan/fzf-lua/wiki/Advanced#explore-changes-from-a-git-branch
-          local filename = fzf_lua.path.entry_to_file(sel, action_opts).path
-          algo.update_file_score(filename, {
-            update_type = "increase",
-            cwd = cwd,
-            db_dir = db_dir,
-            fd_cmd = fd_cmd,
-          })
-        end
-      end)
-
-      return action(selected, action_opts)
-    end
+  if vim.fn.executable "fdfind" == 1 then
+    cmd = string.format("fdfind %s", fd_args)
+  elseif vim.fn.executable "fd" == 1 then
+    cmd = string.format("fd %s", fd_args)
+  elseif vim.fn.executable "rg" == 1 then
+    -- return [[rg --files -g "\!.git" "$(pwd)"]]
+    cmd = string.format([[rg --files -g "!.git"]], opts.cmd or vim.uv.cwd())
+  else
+    FzfLua.utils.warn "[fzf-lua-frecency] 'all_files' requires 'fd' or 'rg'."
+    return nil
   end
-
-  local actions = vim.tbl_deep_extend("force", fzf_lua.defaults.actions.files, {
-    enter = wrapped_enter(fzf_lua.defaults.actions.files.enter),
-    ["ctrl-x"] = {
-      fn = function(selected, action_opts)
-        for _, sel in ipairs(selected) do
-          if display_score then
-            sel = h.strip_score(sel)
-          end
-
-          local filename = fzf_lua.path.entry_to_file(sel, action_opts).path
-          algo.update_file_score(filename, {
-            update_type = "remove",
-            cwd = cwd,
-            db_dir = db_dir,
-            fd_cmd = fd_cmd,
-          })
+  for k, v in pairs {
+    follow = opts.toggle_follow_flag or "-L",
+    hidden = opts.toggle_hidden_flag or "--hidden",
+    no_ignore = opts.toggle_ignore_flag or "--no-ignore",
+  } do
+    (function()
+      local toggle, is_find = opts[k], nil
+      -- Do nothing unless opt was set
+      if opts[k] == nil then return end
+      if cmd:match "^dir" then return end
+      if cmd:match "^find" then
+        if k == "no_ignore" then return end
+        if k == "hidden" then
+          is_find = true
+          toggle = not opts[k]
+          v = [[\! -path '*/.*']]
         end
-      end,
-      reload = true,
-    },
-  })
+      end
+      cmd = FzfLua.utils.toggle_cmd_flag(cmd, v, toggle, is_find)
+    end)()
+  end
+  return cmd
+end
 
+--- @diagnostic disable-next-line: unused-local
+M.setup = function(opts)
+  -- Singleton setup
+  if M._did_setup then return end
+  M._did_setup = true
+
+  -- Trigger lazy loading if need be, creates the FzfLua global object
+  require "fzf-lua"
+
+  -- Register as an fzf-lua extenstion, merge default opts with users' setup opts
+  FzfLua.register_extension("frecency", M.frecency, vim.tbl_deep_extend("keep", opts or {}, {
+      -- fzf-lua-frecency specific defaults
+      cwd_only = false,
+      all_files = nil,
+      stat_file = true,
+      display_score = true,
+      -- Relevant options from fzf-lua's default `files` options
+      _type = "file", -- Adds `fn_preprocess` if required
+      previewer = FzfLua.defaults.files.previewer, -- Inherit from default previewer (if `bat`)
+      multiprocess = true,
+      file_icons = true,
+      color_icons = true,
+      git_icons = false,
+      fzf_opts = {
+        ["--multi"] = true,
+        ["--scheme"] = "path",
+        ["--no-sort"] = true,
+      },
+      winopts = {
+        title = " Frecency ",
+        preview = { winopts = { cursorline = false, }, },
+      },
+      -- Display cwd (if different) and action (ctrl-x) headers
+      _headers = { "cwd", "actions", },
+      -- Inherit actions from the users' setup/global `actions.files`
+      _actions = function() return FzfLua.config.globals.actions.files end,
+      -- Adds `ctrl-x` to the default actions
+      actions = {
+        ["ctrl-x"] = {
+          fn = function(selected, o)
+            for _, sel in ipairs(selected) do
+              local filename = FzfLua.path.entry_to_file(sel, o).path
+              algo.update_file_score(filename, { update_type = "remove", })
+            end
+          end,
+          desc = "delete-score",
+          header = "delete a frecency score",
+          reload = true,
+        },
+      },
+    }),
+    true)
+  -- Update score of all files when editing / changing windows
+  vim.api.nvim_create_autocmd({ "BufWinEnter", }, {
+    group = vim.api.nvim_create_augroup("FzfLuaFrecency", { clear = true, }),
+    callback = function(ev)
+      local current_win = vim.api.nvim_get_current_win()
+      if vim.api.nvim_win_get_config(current_win).relative ~= "" then
+        return
+      end
+      algo.update_file_score(vim.api.nvim_buf_get_name(ev.buf), { update_type = "increase", })
+    end,
+  })
+end
+
+--- @param opts FrecencyFnOpts
+M.frecency = function(opts)
+  -- Does nothing if already called, will lazy load fzf-lua
+  -- and create the FzfLua global object
+  M.setup()
+
+  -- Normalize users' opts with our (registered) defaults and fzf-lua's
+  -- (keymaps, previewers, special options, fzf/skim version check, etc)
+  opts = FzfLua.config.normalize_opts(opts, "frecency")
+  if not opts then return end
+
+  -- Set default cwd if needed
+  opts.cwd = opts.cwd or vim.uv.cwd()
+
+  local db_dir = h.default(opts.db_dir, h.get_default_db_dir())
+  local sorted_files_path = h.get_sorted_files_path(db_dir)
+
+  -- Options that fzf-lua's multiprocess does not serialize
+  -- these aren't included in the fn_transform callback opts
   --- @type GetFnTransformOpts
   local encodeable_opts = {
-    cwd = cwd,
-    display_score = display_score,
-    debug = debug,
     db_dir = db_dir,
-    fd_cmd = fd_cmd,
+    stat_file = opts.stat_file,
+    display_score = opts.display_score,
   }
 
-  -- RPC worked fine on linux, be was hanging on mac - specifically vim.rpcrequest
-  -- using basic string interpolation works well since all the opts that are used can be stringified
-  local fn_transform_str = string.format([[
-    local abs_file = ...
-    local rpc_opts = vim.mpack.decode(%q)
-    return require "fzf-lua-frecency.fn_transform".get_fn_transform(rpc_opts)(abs_file)
-  ]], vim.mpack.encode(encodeable_opts))
-
-  local fn_transform
-  local fn_transform_ok, fn_transform_res = pcall(loadstring, fn_transform_str)
-  if fn_transform_ok then
-    fn_transform = fn_transform_res
-  else
-    fn_transform = function(file) return require "fzf-lua".make_entry.file(file) end
+  -- Clear the global db vars on exit, only matters on `multiprocess=false`
+  -- with `multiprocess=true` fn_preprocess is called in the headless process
+  -- and the global vars are created there
+  opts.fn_selected = function(...)
+    _G._fzf_lua_frecency_dated_files = nil
+    _G._fzf_lua_frecency_max_scores = nil
+    FzfLua.actions.act(...)
   end
 
-  -- relevant options from the default `files` options
-  -- https://github.com/ibhagwan/fzf-lua/blob/f972ad787ee8d3646d30000a0652e9b168a90840/lua/fzf-lua/defaults.lua#L336-L360
-  local default_opts = {
-    actions = actions,
-    previewer = "builtin",
-    file_icons = true,
-    color_icons = true,
-    git_icons = false,
-    fzf_opts = {
-      ["--multi"] = true,
-      ["--scheme"] = "path",
-      ["--no-sort"] = true,
-      ["--header"] = (":: <%s> to %s"):format(
-        fzf_lua.utils.ansi_from_hl("FzfLuaHeaderBind", "ctrl-x"),
-        fzf_lua.utils.ansi_from_hl("FzfLuaHeaderText", "delete a frecency score")
-      ),
-    },
-    winopts = {
-      preview = {
-        winopts = { cursorline = false, },
-      },
-    },
-    multiprocess = true,
-    fn_transform = fn_transform,
-  }
-  local fzf_exec_opts = vim.tbl_deep_extend("force", default_opts, opts)
+  -- RPC worked fine on linux, be was hanging on mac - specifically vim.rpcrequest
+  -- using basic string interpolation works well since all the opts that are used
+  -- can be stringified
+  opts.fn_transform = string.format([[
+    vim.opt.runtimepath:append("%s")
+    local rpc_opts = vim.mpack.decode(%q)
+    return require "fzf-lua-frecency.fn_transform".get_fn_transform(rpc_opts)
+  ]], __RTP__, vim.mpack.encode(encodeable_opts))
 
-  local cat_cmd = table.concat({
-    "cat",
-    sorted_files_path,
-    "2>/dev/null",
-  }, " ")
+  -- Create the shell command, adds file enumeration (fd|rg) and dedup (awk)
+  opts.cmd = (function()
+    -- If caller did not specifically set `all_files` set to true if `cwd_only=true`
+    local all_files = opts.all_files == nil and opts.cwd_only or opts.all_files
+    local cat_cmd = table.concat({
+      "cat",
+      sorted_files_path,
+      "2>/dev/null",
+    }, " ")
+    if not all_files then return cat_cmd end
+    local all_files_cmd = get_files_cmd(opts)
+    -- `all_files_cmd` will return nil of fd|rg aren't installed
+    if not all_files_cmd then return cat_cmd end
+    local awk_cmd = "awk '!x[$0]++'" -- https://stackoverflow.com/a/11532198
+    return ("(%s; %s) | %s"):format(cat_cmd, all_files_cmd, awk_cmd)
+  end)()
 
-  local awk_cmd = "awk '!x[$0]++'" -- https://stackoverflow.com/a/11532198
-  local cmd = ("(%s; %s) | %s"):format(cat_cmd, fd_cmd, awk_cmd)
-  fzf_lua.fzf_exec(cmd, fzf_exec_opts)
+  -- Set title flags (h|i|f) based on hidden/no-ignore/follow flags
+  opts = FzfLua.core.set_title_flags(opts, { "cmd", })
+  return FzfLua.fzf_exec(opts.cmd, opts)
 end
 
 --- @class ClearDbOpts
@@ -149,14 +197,13 @@ end
 --- Does not delete `db_dir` itself or anything else in `db_dir`
 --- @param opts? ClearDbOpts
 M.clear_db = function(opts)
-  local h = require "fzf-lua-frecency.helpers"
   opts = opts or {}
   local db_dir = h.default(opts.db_dir, h.get_default_db_dir())
-  local sorted_files_dir = vim.fs.joinpath(db_dir, "cwds")
+  local sorted_files_path = h.get_sorted_files_path(db_dir)
   local dated_files_path = h.get_dated_files_path(db_dir)
   local max_scores_path = h.get_max_scores_path(db_dir)
 
-  vim.fn.delete(sorted_files_dir, "rf")
+  vim.fn.delete(sorted_files_path)
   vim.fn.delete(dated_files_path)
   vim.fn.delete(max_scores_path)
 end


### PR DESCRIPTION
Hi @elanmed,

First, ty for writing this wonderful project, I didn't think fzf-lua was missing anything but this is quite cool and well done and I'm going to add this to my personal arsenal :-)

I see this as a  potential replacement for `files|oldfiles` and wanted to discuss with you the proposed changes.

This is still WIP (testing, etc) as I wanted to first get your feedback before I remove more parts of the code and make further adjustments.

The biggest change would be dropping the `cwds` folder and separate databases for each `cwd`, this makes us cwd dependent and too limiting, if I change cwd to a project's sub directory or wish to see a full picture of all recent files (a-la `oldfiles`).

With the proposed changes `fn_transform` does the filtering based on the current `cwd` so we can handle the combined sorted files database and `cwd_only` (which is already an option in fzf-lua used with any file-type picker) can control the display.

I currently piggybacked the `cwd_only` option to decide if we show the scoreless files after the sorted files but this probably needs a separate option.

My vision is this:
1. Replacement for `files` combined with `oldfiles cwd_only=true`
```lua
:lua require("fzf-lua-frecency").frecency({cwd_only=true})
```
<img width="1019" height="571" alt="image" src="https://github.com/user-attachments/assets/c9a568d8-f4f5-4d23-8dce-8cc94724338e" />


2. Replacement for the global `oldfiles` which shows all recent files without appending the `fd` command:
```lua
:lua require("fzf-lua-frecency").frecency({})
```

<img width="1028" height="546" alt="image" src="https://github.com/user-attachments/assets/b63cdf07-94a1-4de5-86a8-0b4c3f0a57a1" />


In addition we no longer use the `wrapped_enter` as I find this also limits updating the scores only when using fzf-lua-frecency, instead the user should call setup once to setup the BufWinEnter autocmd (we can also call the setup automatically for the user once on the initial load, up to discussion).

Overall, there are a few more changes I'd like to add in fzf-lua as well, a proper interface for registering the extension which will add `:FzfLua frecency` command so users don't need to call `require("fzf-lua-frecency")`.

Let me know your thoughts?