### PR TITLE
feat: remove `awk` dependency (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ require('fzf-lua-frecency').frecency({
 
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
 - [`fd`](https://github.com/sharkdp/fd), [`rg`](https://github.com/BurntSushi/ripgrep) or [`find`](https://www.gnu.org/software/findutils/)
-- `awk`
 - Neovim 0.9+
 
 ## Similar plugins

--- a/lua/fzf-lua-frecency/algo.lua
+++ b/lua/fzf-lua-frecency/algo.lua
@@ -181,7 +181,7 @@ M.update_file_score = function(filename, opts)
 
   fs.write {
     path = sorted_files_path,
-    data = sorted_files_str,
+    data = sorted_files_str .. "\n", -- fn_transform EOF marker
     encode = false,
   }
 end

--- a/lua/fzf-lua-frecency/health.lua
+++ b/lua/fzf-lua-frecency/health.lua
@@ -27,13 +27,6 @@ function M.check()
     })
   end
 
-  if vim.fn.executable "awk" == h.vimscript_true then
-    vim.health.ok "'awk' is installed"
-  else
-    vim.health.error("'fzf-lua' is not installed", {
-      "On Windows, one installation method for 'awk' is through the choco package manager: https://community.chocolatey.org/packages/awk",
-    })
-  end
 end
 
 return M

--- a/tests/test_algo.lua
+++ b/tests/test_algo.lua
@@ -107,7 +107,7 @@ T["#update_file_score"]["update_type=increase"]["adds score entry for new file"]
   local dated_files = fs.read(dated_files_path)
   local date_at_score_one = dated_files[db_index][test_file_a]
   MiniTest.expect.equality(date_at_score_one, date_at_score_one_now)
-  MiniTest.expect.equality(read_sorted(), test_file_a .. "\n")
+  MiniTest.expect.equality(read_sorted(), test_file_a .. "\n\n")
 end
 
 T["#update_file_score"]["update_type=increase"]["increments score on repeated calls"] = function()
@@ -160,7 +160,7 @@ T["#update_file_score"]["update_type=increase"]["recalculates all scores when ad
     fs.read(dated_files_path)[db_index][test_file_b],
     algo.compute_date_at_score_one { now = now_after_30_min, score = score_when_adding, }
   )
-  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n" .. test_file_a .. "\n")
+  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n" .. test_file_a .. "\n\n")
 end
 
 T["#update_file_score"]["update_type=increase"]["filters deleted files when stat_file=true"] = function()
@@ -193,7 +193,7 @@ T["#update_file_score"]["update_type=increase"]["filters deleted files when stat
     fs.read(dated_files_path)[db_index][test_file_b],
     algo.compute_date_at_score_one { now = now_after_30_min, score = score_when_adding, }
   )
-  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n")
+  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n\n")
 end
 
 T["#update_file_score"]["update_type=increase"]["avoids adding deleted files when stat_file=true"] = function()
@@ -242,7 +242,7 @@ T["#update_file_score"]["update_type=increase"]["filters directories when stat_f
     fs.read(dated_files_path)[db_index][test_file_b],
     algo.compute_date_at_score_one { now = now_after_30_min, score = score_when_adding, }
   )
-  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n")
+  MiniTest.expect.equality(read_sorted(), test_file_b .. "\n\n")
 end
 
 T["#update_file_score"]["update_type=increase"]["avoids adding directories when stat_file=true"] = function()
@@ -270,7 +270,7 @@ T["#update_file_score"]["update_type=remove"]["removes entry for existing file"]
   })
 
   MiniTest.expect.equality(fs.read(dated_files_path)[db_index][test_file_a], date_at_score_one_now)
-  MiniTest.expect.equality(read_sorted(), test_file_a .. "\n")
+  MiniTest.expect.equality(read_sorted(), test_file_a .. "\n\n")
 
   algo._now = function() return now end
   algo.update_file_score(test_file_a, {
@@ -279,7 +279,7 @@ T["#update_file_score"]["update_type=remove"]["removes entry for existing file"]
   })
 
   MiniTest.expect.equality(fs.read(dated_files_path)[db_index][test_file_a], nil)
-  MiniTest.expect.equality(read_sorted(), "")
+  MiniTest.expect.equality(read_sorted(), "\n")
 end
 
 return T

--- a/tests/test_init.lua
+++ b/tests/test_init.lua
@@ -47,7 +47,7 @@ T["#frecency"]["builds the correct fzf command and calls fzf_exec"] = function()
 
   local cat_cmd = ("cat '%s' 2>/dev/null"):format(sorted_files_path)
   local fd_cmd = "fd --absolute-path --color=never --hidden --type f --type l --exclude .git"
-  MiniTest.expect.equality(called.cmd, ("(%s ; %s) | awk '!x[$0]++'"):format(cat_cmd, fd_cmd))
+  MiniTest.expect.equality(called.cmd, ("%s ; %s"):format(cat_cmd, fd_cmd))
 end
 
 local function write_file(path, contents)


### PR DESCRIPTION
As discussed, I came up with a fairly simply solution of adding an extra line break to `sorted_files` to mark the end of file which we then use to dedup entries coming from `all_files=true`.

As you can see from the code it's pretty much "free" as we always know if the file was seen or not due to `date_at_score_one`.

This commit also fixes the testing and healcheck, I didn't update the doc file as I saw you're using the CI for auto doc generation.

Note that for `multiprocess=false` this requires a tiny fix in fzf-lua https://github.com/ibhagwan/fzf-lua/commit/504b45d6cedec32d6f0ddeb82f3d7117a94b622b due to the `fn_transform` being iterated  backwards due to another issue https://github.com/ibhagwan/fzf-lua/issues/2185 which funny enough was opened by you :-)