### PR TITLE
feat: allow overriding cmd

### DIFF
--- a/lua/fzf-lua-frecency/init.lua
+++ b/lua/fzf-lua-frecency/init.lua
@@ -213,7 +213,7 @@ M.frecency = function(opts)
     return require "fzf-lua-frecency.fn_transform".get_fn_transform(rpc_opts)
   ]], __RTP__, vim.mpack.encode(encodeable_opts))
 
-  opts.cmd = (function()
+  opts.cmd = opts.cmd or (function()
     local cat_cmd = table.concat({
       h.IS_WINDOWS and "type" or "cat",
       vim.fn.shellescape(h.get_native_filepath(sorted_files_path)),


### PR DESCRIPTION
`frecency()` calls should allow overriding `opts.cmd`, this is essential for some actions to work, e.g. the following action to include/exclude dirs from the picker's result:

```lua
local fzf_utils = require('fzf-lua.utils')
local actions = require('fzf-lua.actions')

---Include directories, not only files when using the `files` picker
---@return nil
function actions.toggle_dir(_, opts)
  local flag ---@type string?
  local flag_cmd_idx ---@type integer?
  local cmds = vim.iter(opts.cmd:gmatch('([^|;&]+[|;&]*)')):totable()

  -- Handle multiple cmds in one string, e.g. fzf-lua-frecency uses two
  -- commands in a row: 'cat ... ; fd ...'
  --
  -- fzf-lua-frecency does not support overriding cmd passed in `opts` yet
  -- TODO: make a PR for it
  for i, cmd in ipairs(cmds) do
    local exec = cmd:match('^%s*(%S+)')
    if exec == 'fd' or exec == 'fdfind' then
      flag = '--type d'
      flag_cmd_idx = i
      break
    end
    if exec == 'find' then
      flag = '-type d'
      flag_cmd_idx = i
      break
    end
  end
  if not flag or not flag_cmd_idx then
    return
  end

  cmds[flag_cmd_idx] = fzf_utils.toggle_cmd_flag(cmds[flag_cmd_idx], flag)

  opts.__call_fn(vim.tbl_deep_extend('force', opts.__call_opts, {
    cmd = table.concat(cmds),
    resume = true,
  }))
end
```

The above action works for `fzf.files` and I can toggle dir inclusion with a key, but it does not work for frecency picker. This PR should address this issue by allowing overriding `opts.cmd` in `frecency` calls.